### PR TITLE
Change package.json's project name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Interface.js server",
+  "name": "InterfaceJSserver",
   "main": "index.html",
   "window": {
     "show":false,


### PR DESCRIPTION
When performing an npm install, npm (newest version) complains about the name "Interface.js server". Removing the space and punctuation fixed the error.
